### PR TITLE
fix: upgrade qs to >=6.15.2 to resolve CVE-2026-8723 (DoS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "resolutions": {
     "systeminformation": "5.31.7",
     "path-to-regexp": "8.4.2",
-    "tmp": ">=0.2.6"
+    "tmp": ">=0.2.6",
+    "qs": ">=6.15.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,12 +5939,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.14.1":
-  version: 6.14.2
-  resolution: "qs@npm:6.14.2"
+"qs@npm:>=6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add `"qs": ">=6.15.2"` to `resolutions` to fix CVE-2026-8723 (remotely triggerable DoS in `qs.stringify`)
- `qs` is a transitive dependency via `@cypress/request`

## Test plan

- [x] `yarn why qs` confirms version 6.15.2 installed
- [ ] Verify Dependabot alert #97 is resolved after merge

	🤖 Generated with [Qoder][https://qoder.com]

## Summary by Sourcery

Build:
- 在 `package.json` 的 `resolutions` 中将 `qs` 固定为 6.15.2 或更高版本，以覆盖存在漏洞的传递依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Pin qs to version 6.15.2 or higher in package.json resolutions to override the vulnerable transitive dependency.

</details>