### PR TITLE
fix: correct useOptimistic async pattern and add behavioral test

### DIFF
--- a/src/__tests__/pages/Settings/Settings.test.tsx
+++ b/src/__tests__/pages/Settings/Settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Settings from "@/pages/Settings";
 
@@ -69,9 +69,46 @@ describe("Settings", () => {
     const displayNameInput = container.querySelector('input[id="displayName"]') as HTMLInputElement;
     const emailInput = container.querySelector('input[id="email"]') as HTMLInputElement;
 
+    // Inputs should be initialized from saved data
     expect(displayNameInput?.value).toBe("张三");
     expect(emailInput?.value).toBe("zhangsan@example.com");
+
+    // The optimistic display card should also reflect the same initial saved data
+    const cardBody = container.querySelectorAll(".ant-card")[1]; // inner card
+    expect(cardBody).toBeTruthy();
+    expect(cardBody?.textContent).toContain("当前生效的设置（乐观更新）");
+    expect(cardBody?.textContent).toContain("张三");
+    expect(cardBody?.textContent).toContain("zhangsan@example.com");
   });
+
+  it("optimistically updates card on submit before async save resolves", async () => {
+    // This test uses real timers because antd form.validateFields() relies on
+    // microtask scheduling that doesn't resolve properly with fake timers.
+    vi.useRealTimers();
+
+    const { container } = render(<Settings />);
+
+    const displayNameInput = container.querySelector('input[id="displayName"]') as HTMLInputElement;
+    const emailInput = container.querySelector('input[id="email"]') as HTMLInputElement;
+
+    // Fill form with new values
+    fireEvent.change(displayNameInput, { target: { value: "李四" } });
+    fireEvent.change(emailInput, { target: { value: "lisi@example.com" } });
+
+    // Submit the form
+    const submitButton = container.querySelector("button.ant-btn-primary") as HTMLButtonElement;
+    expect(submitButton).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    // Optimistic update: card should reflect new values while the 2s save is in-flight
+    const getCardText = () => container.querySelectorAll(".ant-card")[1]?.textContent || "";
+    await waitFor(() => {
+      expect(getCardText()).toContain("李四");
+      expect(getCardText()).toContain("lisi@example.com");
+    }, { timeout: 1000 });
+  }, 10000);
 
   it("renders card component", () => {
     const { container } = render(<Settings />);

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -27,19 +27,20 @@ const Settings: React.FC = memo(() => {
     try {
       const values = await form.validateFields();
 
-      // 乐观更新：立即让展示区显示新值
-      startTransition(() => {
+      // React 19: 异步操作必须在 startTransition 内部，
+      // 这样 useOptimistic 才能在整个异步过程中保持乐观值
+      startTransition(async () => {
         addOptimisticData(values);
-      });
 
-      // 模拟 API 调用（2秒延迟）
-      await new Promise((resolve) => {
-        setTimeout(resolve, 2000);
-      });
+        // 模拟 API 调用（2秒延迟）
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2000);
+        });
 
-      // 模拟成功：实际场景中 savedData 应从服务端刷新
-      Object.assign(savedData, values);
-      message.success("保存成功");
+        // 模拟成功：实际场景中 savedData 应从服务端刷新
+        Object.assign(savedData, values);
+        message.success("保存成功");
+      });
     } catch (e: any) {
       if (e?.errorFields) return;
       message.error(e?.message || '保存失败');


### PR DESCRIPTION
## Summary

- Fix the `useOptimistic` implementation: move async work **inside** the `startTransition` callback so the optimistic value persists during the async operation (previously it reverted immediately because the transition completed synchronously)
- Add test coverage per PR #916 review feedback:
  - Assert the optimistic display card shows initial saved data on load
  - Verify the full optimistic update flow (card updates immediately on submit, before the 2s simulated API call resolves)

## Test plan

- [x] All 58 unit tests pass (including the new behavioral test)
- [ ] Manually verify: submit Settings form → card immediately shows new values → after 2s shows "保存成功"

	🤖 Generated with [Qoder][https://qoder.com]

## Summary by Sourcery

修复乐观设置更新流程，以便在异步保存期间保持乐观值处于活动状态，并添加测试来验证该行为。

Bug 修复：
- 确保 `useOptimistic` 在整个异步保存操作期间保持乐观的设置值，通过在 `startTransition` 内运行异步工作来实现。

测试：
- 添加一个断言，用于检查乐观设置卡片在初始状态下是否反映已保存的用户数据。
- 添加一个行为测试，用于验证设置卡片在提交时，会在模拟的 API 调用完成之前先进行乐观更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix optimistic settings update flow to keep optimistic values active during async saves and add tests to validate the behavior.

Bug Fixes:
- Ensure useOptimistic keeps the optimistic settings values during the entire async save operation by running the async work inside startTransition.

Tests:
- Add an assertion that the optimistic settings card initially reflects the saved user data.
- Add a behavioral test that verifies the settings card updates optimistically on submit before the simulated API call resolves.

</details>