### PR TITLE
fix: move error handling inside startTransition callback

### DIFF
--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -24,14 +24,22 @@ const Settings: React.FC = memo(() => {
   );
 
   const handleSubmit = useCallback(async () => {
+    let values: FormValues;
     try {
-      const values = await form.validateFields();
+      values = await form.validateFields();
+    } catch (e: any) {
+      // 表单校验错误：antd 已自动提示，无需额外处理
+      if (e?.errorFields) return;
+      message.error(e?.message || '保存失败');
+      return;
+    }
 
-      // React 19: 异步操作必须在 startTransition 内部，
-      // 这样 useOptimistic 才能在整个异步过程中保持乐观值
-      startTransition(async () => {
-        addOptimisticData(values);
-
+    // React 19: 异步操作必须在 startTransition 内部，
+    // 这样 useOptimistic 才能在整个异步过程中保持乐观值。
+    // 注意：startTransition 不会 await 回调，错误必须在内部捕获。
+    startTransition(async () => {
+      addOptimisticData(values);
+      try {
         // 模拟 API 调用（2秒延迟）
         await new Promise((resolve) => {
           setTimeout(resolve, 2000);
@@ -40,11 +48,10 @@ const Settings: React.FC = memo(() => {
         // 模拟成功：实际场景中 savedData 应从服务端刷新
         Object.assign(savedData, values);
         message.success("保存成功");
-      });
-    } catch (e: any) {
-      if (e?.errorFields) return;
-      message.error(e?.message || '保存失败');
-    }
+      } catch (e: any) {
+        message.error(e?.message || '保存失败');
+      }
+    });
   }, [form, addOptimisticData]);
 
   return (


### PR DESCRIPTION
## Summary

- `startTransition` does not await its async callback — errors inside it result in unhandled promise rejections, bypassing any outer try/catch
- Split error handling into two layers:
  - Outer: handles `form.validateFields()` errors (form validation)
  - Inner (inside transition): handles API/save errors with its own try/catch
- This ensures `message.error()` fires correctly if the async save fails

## Test plan

- [x] All 58 unit tests pass
- [ ] Manually verify: if API throws, error toast appears (currently simulated API always succeeds, but the pattern is now correct for real usage)

	🤖 Generated with [Qoder][https://qoder.com]

## Summary by Sourcery

Bug Fixes:
- 在 `startTransition` 回调内部处理异步错误，这样在保存失败时将不再产生未处理的 Promise 拒绝，并能正确为用户触发错误提示（toast）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle async errors inside the startTransition callback so save failures no longer produce unhandled promise rejections and correctly trigger error toasts for users.

</details>